### PR TITLE
Allow indicator to snap to hex facings

### DIFF
--- a/about-face.js
+++ b/about-face.js
@@ -38,12 +38,18 @@ Hooks.on("renderSceneConfig", (app, html) => {
 			notes: game.i18n.localize("about-face.options.lockRotation.hint"),
 			default: app.object.data?.flags?.[MODULE_ID]?.lockRotation ?? game.settings.get(MODULE_ID, "lockRotation"),
 		},
-		lockArrowRotation: {
-			type: "checkbox",
-			label: game.i18n.localize("about-face.options.lockArrowRotation.name"),
-			notes: game.i18n.localize("about-face.options.lockArrowRotation.hint"),
-			default: app.object.data?.flags?.[MODULE_ID]?.lockArrowRotation ?? game.settings.get(MODULE_ID, "lockArrowRotation"),
-		},
+/*    lockArrowToHexFace: {
+      type: "checkbox",
+      label: game.i18n.localize("about-face.options.lockArrowToHexFace.name"),
+      notes: game.i18n.localize("about-face.options.lockArrowToHexFace.hint"),
+      default: game.settings.get(MODULE_ID, "lockArrowToHexFace"),
+    }, */
+    lockArrowRotation: {
+      type: "checkbox",
+      label: game.i18n.localize("about-face.options.lockArrowRotation.name"),
+      notes: game.i18n.localize("about-face.options.lockArrowRotation.hint"),
+      default: app.object.data?.flags?.[MODULE_ID]?.lockArrowRotation ?? game.settings.get(MODULE_ID, "lockArrowRotation"),
+    },
 	};
 	injectConfig.inject(app, html, data, app.object);
 });

--- a/lang/en.json
+++ b/lang/en.json
@@ -19,10 +19,14 @@
 				"name": "Indicator Distance",
 				"hint": "Set the multiplier for the indicator's distance. Math: Highest Size x (Multiplier / 2)."
 			},
-			"lockArrowRotation": {
-				"name": "Lock Indicator Rotation",
-				"hint": "The indicator won't change when the token moves. Use SHIFT + direction key to rotate the indicator."
-			},
+      "lockArrowToHexFace": {
+        "name": "Lock Indicator to Hex face",
+        "hint": "On Hex maps, the indicator will orient itself to the 'best' HEX facing after the move"
+      },
+      "lockArrowRotation": {
+        "name": "Lock Indicator Rotation",
+        "hint": "The indicator won't change when the token moves. Use SHIFT + direction key to rotate the indicator."
+      },
 			"lockRotation": {
 				"name": "Lock Rotation",
 				"hint": "Every token will be created with the Lock Rotation Token Configuration toggled on."

--- a/lang/en.json
+++ b/lang/en.json
@@ -21,7 +21,7 @@
 			},
       "lockArrowToHexFace": {
         "name": "Lock Indicator to Hex face",
-        "hint": "On Hex maps, the indicator will orient itself to the 'best' HEX facing after the move"
+        "hint": "On Hex maps, the indicator will orient itself to the 'best' HEX facing after the move.  This setting is ignored if 'Lock Indicator Rotation' is on."
       },
       "lockArrowRotation": {
         "name": "Lock Indicator Rotation",

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -130,6 +130,14 @@ export function registerSettings() {
 		type: Boolean,
 	});
 
+  game.settings.register(MODULE_ID, "lockArrowToHexFace", {
+    name: "about-face.options.lockArrowToHexFace.name",
+    hint: "about-face.options.lockArrowToHexFace.hint",
+    scope: "world",
+    config: true,
+    default: false,
+    type: Boolean,
+  });
 	game.settings.register(MODULE_ID, "lockRotation", {
 		name: "about-face.options.lockRotation.name",
 		hint: "about-face.options.lockRotation.hint",


### PR DESCRIPTION
This solves https://github.com/mclemente/about-face/issues/19

It adds a system setting:
![image](https://user-images.githubusercontent.com/8931036/148608254-9b3233ce-bfff-4768-9854-b418758d1030.png)

And when tokens are moved (only on hex maps), it will determine the closest facing
![image](https://user-images.githubusercontent.com/8931036/148608684-291f9bd6-bc86-4ec8-aa77-29c09384ccaa.png)
![image](https://user-images.githubusercontent.com/8931036/148608710-0d37426e-951b-4c42-be73-5771bfe301c9.png)

And sorry about the spacing issue... I guess my IDE isn't using the same spaces/tab as yours.