### PR TITLE
settings to disable auto rotation unless key is pressed

### DIFF
--- a/about-face.js
+++ b/about-face.js
@@ -9,10 +9,24 @@ import { injectConfig } from "./scripts/injectConfig.js";
 import { drawAboutFaceIndicator, onCanvasReady, onPreCreateToken, onPreUpdateToken, updateSettings } from "./scripts/logic.js";
 import { MODULE_ID, registerSettings, renderSettingsConfigHandler, renderTokenConfigHandler } from "./scripts/settings.js";
 
+export let toggleTokenRotation = false;
+
 Hooks.once("init", () => {
 	libWrapper.register(MODULE_ID, "Token.prototype.refresh", drawAboutFaceIndicator);
 	registerSettings();
 	updateSettings();
+
+	game.keybindings.register(MODULE_ID, "toggleTokenRotation", {
+		name: "about-face.keybindings.toggleTokenRotation.name",
+		hint: "about-face.keybindings.toggleTokenRotation.hint",
+		editable: [{ key: "KeyZ" }],
+		onDown: () => {
+			toggleTokenRotation = !toggleTokenRotation;
+			ui.notifications.notify("About Face: " + game.i18n.localize(`about-face.keybindings.toggleTokenRotation.tooltip.${toggleTokenRotation}`));
+		},
+		restricted: false,
+		precedence: CONST.KEYBINDING_PRECEDENCE.NORMAL,
+	});
 });
 Hooks.on("preCreateToken", onPreCreateToken);
 Hooks.on("preUpdateToken", onPreUpdateToken);

--- a/lang/en.json
+++ b/lang/en.json
@@ -1,5 +1,15 @@
 {
 	"about-face": {
+		"keybindings": {
+			"toggleTokenRotation": {
+				"name": "Toggle Token Rotation",
+				"hint": "Tokens won't rotate during movement. Useful for games with Vision Angles.",
+				"tooltip": {
+					"true": "Token Rotation is off.",
+					"false": "Token Movement is on."
+				}
+			}
+		},
 		"sceneConfig": {
 			"hint": "Configure the About Face settings for this scene.",
 			"apply": "Apply to existing tokens",
@@ -48,10 +58,6 @@
 			"rememberTokenPrevPos": {
 				"name": "Step Back / Remember Token's Previous Position",
 				"hint": "If a token moves to its previous position, its indicator won't change. Useful for games with Vision Angles."
-			},
-			"tokenAutoRotateOptInPerMovement": {
-				"name": "Token rotation is opt in per movement",
-				"hint": "Token will not auto rotate unless \"z\" key is pressed during movement. Useful for games with Vision Angles."
 			},
 			"enable-indicator": {
 				"name": "Enable token indicators",

--- a/lang/en.json
+++ b/lang/en.json
@@ -49,6 +49,10 @@
 				"name": "Step Back / Remember Token's Previous Position",
 				"hint": "If a token moves to its previous position, its indicator won't change. Useful for games with Vision Angles."
 			},
+			"tokenAutoRotateOptInPerMovement": {
+				"name": "Token rotation is opt in per movement",
+				"hint": "Token will not auto rotate unless \"z\" key is pressed during movement. Useful for games with Vision Angles."
+			},
 			"enable-indicator": {
 				"name": "Enable token indicators",
 				"hint": "Adds an indicator for direction to tokens",

--- a/scripts/logic.js
+++ b/scripts/logic.js
@@ -116,6 +116,7 @@ export function onPreUpdateToken(tokenDocument, updates) {
 			return;
 		}
 	} else if (("x" in updates || "y" in updates) && !canvas.scene.getFlag(MODULE_ID, "lockArrowRotation")) {
+		if (game.settings.get(MODULE_ID, "tokenAutoRotateOptInPerMovement") && !keyboard.downKeys.has("KeyZ")) return;
 		//get previews and new positions
 		const prevPos = { x: tokenDocument.data.x, y: tokenDocument.data.y };
 		const newPos = { x: updates.x ?? tokenDocument.data.x, y: updates.y ?? tokenDocument.data.y };

--- a/scripts/logic.js
+++ b/scripts/logic.js
@@ -1,3 +1,4 @@
+import { toggleTokenRotation } from "../about-face.js";
 import { IndicatorMode, MODULE_ID } from "./settings.js";
 
 let indicatorColor, indicatorDistance;
@@ -116,7 +117,7 @@ export function onPreUpdateToken(tokenDocument, updates) {
 			return;
 		}
 	} else if (("x" in updates || "y" in updates) && !canvas.scene.getFlag(MODULE_ID, "lockArrowRotation")) {
-		if (game.settings.get(MODULE_ID, "tokenAutoRotateOptInPerMovement") && !keyboard.downKeys.has("KeyZ")) return;
+		if (toggleTokenRotation) return;
 		//get previews and new positions
 		const prevPos = { x: tokenDocument.data.x, y: tokenDocument.data.y };
 		const newPos = { x: updates.x ?? tokenDocument.data.x, y: updates.y ?? tokenDocument.data.y };

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -191,6 +191,15 @@ export function registerSettings() {
 		type: Boolean,
 	});
 
+	game.settings.register(MODULE_ID, "tokenAutoRotateOptInPerMovement", {
+		name: "about-face.options.tokenAutoRotateOptInPerMovement.name",
+		hint: "about-face.options.tokenAutoRotateOptInPerMovement.hint",
+		scope: "world",
+		config: true,
+		default: false,
+		type: Boolean,
+	});
+
 	game.settings.register(MODULE_ID, "flip-or-rotate", {
 		name: "about-face.options.flip-or-rotate.name",
 		hint: "about-face.options.flip-or-rotate.hint",

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -191,15 +191,6 @@ export function registerSettings() {
 		type: Boolean,
 	});
 
-	game.settings.register(MODULE_ID, "tokenAutoRotateOptInPerMovement", {
-		name: "about-face.options.tokenAutoRotateOptInPerMovement.name",
-		hint: "about-face.options.tokenAutoRotateOptInPerMovement.hint",
-		scope: "world",
-		config: true,
-		default: false,
-		type: Boolean,
-	});
-
 	game.settings.register(MODULE_ID, "flip-or-rotate", {
 		name: "about-face.options.flip-or-rotate.name",
 		hint: "about-face.options.flip-or-rotate.hint",


### PR DESCRIPTION
Fixes #25 by making auto rotate opt in per movement.

Adds a settings (default false) to make auto rotation opt in.
With this option set as true, auto token only auto rotates when "z" key is pressed during movement.

We could make the key configurable (instead of hardcoding KeyZ), but I think it's ok to do it later if anyone needs it (using KeyZ as default).